### PR TITLE
Add render challenge inline option (which is now default from installer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@
   if you've done customization of templates you will have to re-do it new way, based
   on new templates. (i18n overrides are still fine and backwards compat). Sorry,
   we are pre-1.0 because we are still figuring out the API patterns we need!
+
+* Also means challenge pages are delivered with HTTP status 403 now. And headers for no http
+  caching.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.3.0
+
+* New direct inline challenge (instead of redirect) available and is default.
+  Opt into old behavior with config `redirect_for_challenge = true`. https://github.com/samvera-labs/bot_challenge_page/pull/2
+
+* To implement that, the way of passing data into challenge templates has changed, and
+  if you've done customization of templates you will have to re-do it new way, based
+  on new templates. (i18n overrides are still fine and backwards compat). Sorry,
+  we are pre-1.0 because we are still figuring out the API patterns we need!

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ To customize the layout or challenge page HTML more further, you can use configu
 ```ruby
 BotChallengePage::BotChallengePageController.bot_challenge_config.challenge_renderer = ()->  {
   render "my_local_view_folder/whatever", layout "another_layout"
-  render layout: "another_layout" # default html but change layout. etc.
 }
 ```
 
@@ -117,7 +116,7 @@ Locally one way to test with a specific rails version appraisal is `bundle exec 
 
 If you make any changes to `Gemfile` you may need to run `bundle exec appraisal install` and commit changes.
 
-**One reason tests are slow** is I think we're running system tests with real turnstile proof-of-work bot detection JS code? (Or is it, when we are are using a CF turnstile testing key that always passes?).  There aren't many tests so it's no big deal, but this is something that could be investigated/optmized more potentially.  
+**One reason tests are slow** is I think we're running system tests with real turnstile proof-of-work bot detection JS code? (Or is it, when we are are using a CF turnstile testing key that always passes?).  There aren't many tests so it's no big deal, but this is something that could be investigated/optmized more potentially.
 
 ## Possible future features?
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The motivating use case is fairly dumb (probably AI-related) crawlers, rather th
 
   * If you do not want to use rack-attack and want challenge on FIRST request, `rails g bot_challenge_page:install --no-rack-attack`
 
+  * By default challenge pages are "inline" at protected URL. To redirect to a separate challenge page URL instead, `--redirect-for-challenge`
+
 * If you are **not using rack-attack**, you need to add a before_action to the controller(s)
   you'd like to protect, eg:
 

--- a/app/controllers/bot_challenge_page/bot_challenge_page_controller.rb
+++ b/app/controllers/bot_challenge_page/bot_challenge_page_controller.rb
@@ -29,12 +29,11 @@ module BotChallengePage
     class_attribute :_track_notification_subscription, instance_accessor: false
 
 
+    # only used if config.redirect_for_challenge is true
     def challenge
-      # possible custom render to choose layouts or templates, but normally
-      # we just do default rails render and this proc is empty.
-      if self.bot_challenge_config.challenge_renderer
-        instance_exec &self.bot_challenge_config.challenge_renderer
-      end
+      # possible custom render to choose layouts or templates, but
+      # default is what would be default template for this action
+      instance_exec &self.bot_challenge_config.challenge_renderer
     end
 
     def verify_challenge

--- a/app/controllers/bot_challenge_page/bot_challenge_page_controller.rb
+++ b/app/controllers/bot_challenge_page/bot_challenge_page_controller.rb
@@ -18,9 +18,7 @@ module BotChallengePage
     # to support different controllers with different config protecting
     # different paths in your app if you like, is why config is with controller
     class_attribute :bot_challenge_config, default: ::BotChallengePage::Config.new
-
-    delegate :cf_turnstile_js_url, :cf_turnstile_sitekey, :still_around_delay_ms, to: :bot_challenge_config
-    helper_method :cf_turnstile_js_url, :cf_turnstile_sitekey, :still_around_delay_ms
+    helper_method :bot_challenge_config
 
     SESSION_DATETIME_KEY = "t"
     SESSION_IP_KEY = "i"

--- a/app/controllers/concerns/bot_challenge_page/enforce_filter.rb
+++ b/app/controllers/concerns/bot_challenge_page/enforce_filter.rb
@@ -27,6 +27,8 @@ module BotChallengePage
 
           Rails.logger.info("#{self.name}: Cloudflare Turnstile challenge redirect: (#{controller.request.remote_ip}, #{controller.request.user_agent}): from #{controller.request.url}")
 
+          # Prevent caching of bot challenge page
+          controller.response.headers["Cache-Control"] = "no-store"
 
           if self.bot_challenge_config.redirect_for_challenge
             # status code temporary

--- a/app/controllers/concerns/bot_challenge_page/enforce_filter.rb
+++ b/app/controllers/concerns/bot_challenge_page/enforce_filter.rb
@@ -26,8 +26,16 @@ module BotChallengePage
           end
 
           Rails.logger.info("#{self.name}: Cloudflare Turnstile challenge redirect: (#{controller.request.remote_ip}, #{controller.request.user_agent}): from #{controller.request.url}")
-          # status code temporary
-          controller.redirect_to controller.bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
+
+
+          if self.bot_challenge_config.redirect_for_challenge
+            # status code temporary
+            controller.redirect_to controller.bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
+          else
+            # hacky way to get config to view template in an arbitrary controller, good enough for now
+            controller.instance_variable_set("@bot_challenge_config", self.bot_challenge_config) unless controller.instance_variable_get("@bot_challenge_config")
+            controller.instance_exec &self.bot_challenge_config.challenge_renderer
+          end
         end
       end
 

--- a/app/models/bot_challenge_page/config.rb
+++ b/app/models/bot_challenge_page/config.rb
@@ -27,6 +27,10 @@ module BotChallengePage
       end
     end
 
+    # Should we redirect to a challenge page (true) or just display it inline
+    # with a 403 status (false)
+    attribute :redirect_for_challenge, default: false
+
     attribute :enabled, default: false # Must set to true to turn on at all
 
     attribute :cf_turnstile_sitekey, default: "1x00000000000000000000AA" # a testing key that always passes
@@ -55,7 +59,9 @@ module BotChallengePage
     attribute :allow_exempt, default: ->(controller, config) { false }
 
     # replace with say `->() { render layout: 'something' }`, or `render "somedir/some_template"`
-    attribute :challenge_renderer, default: ->() { render "bot_challenge_page/bot_challenge_page/challenge" }
+    attribute :challenge_renderer, default: ->() {
+      render "bot_challenge_page/bot_challenge_page/challenge", status: 403
+    }
 
 
     # rate limit per subnet, following lehigh's lead, although we use a smaller

--- a/app/models/bot_challenge_page/config.rb
+++ b/app/models/bot_challenge_page/config.rb
@@ -55,7 +55,7 @@ module BotChallengePage
     attribute :allow_exempt, default: ->(controller, config) { false }
 
     # replace with say `->() { render layout: 'something' }`, or `render "somedir/some_template"`
-    attribute :challenge_renderer, default: nil
+    attribute :challenge_renderer, default: ->() { render "bot_challenge_page/bot_challenge_page/challenge" }
 
 
     # rate limit per subnet, following lehigh's lead, although we use a smaller

--- a/app/views/bot_challenge_page/_local_turnstile_script_tag.html.erb
+++ b/app/views/bot_challenge_page/_local_turnstile_script_tag.html.erb
@@ -32,12 +32,6 @@
 
       result = await response.json();
       if (result["success"] == true) {
-        const dest = new URLSearchParams(window.location.search).get("dest");
-        // For security make sure it only has path and on
-        if (!dest.startsWith("/") || dest.startsWith("//")) {
-          throw new Error("illegal non-local redirect: " + dest);
-        }
-
         // in case this page stays around, (say it was rediret to media asset), let's add a failsafe message after
         // a couple seconds.
         const delay = document.querySelector("#botChallengePageStillAroundTemplate")?.getAttribute("data-still-around-delay-ms") || 1200;
@@ -45,8 +39,19 @@
           _displayStillAroundNote()
         }, delay);
 
-        // replace the challenge page in history
-        window.location.replace(dest);
+        if (result["redirect_for_challenge"] == true) {
+          const dest = new URLSearchParams(window.location.search).get("dest");
+          // For security make sure it only has path and on
+          if (!dest.startsWith("/") || dest.startsWith("//")) {
+            throw new Error("illegal non-local redirect: " + dest);
+          }
+
+          // replace the challenge page in history
+          window.location.replace(dest);
+        } else {
+          // just need to reload and now we'll get through
+          window.location.reload();
+        }
       } else {
         console.error("Turnstile response reported as failure: " + JSON.stringify(result))
         _displayChallengeError();

--- a/app/views/bot_challenge_page/_local_turnstile_script_tag.html.erb
+++ b/app/views/bot_challenge_page/_local_turnstile_script_tag.html.erb
@@ -1,6 +1,7 @@
+<%# locals: (bot_challenge_config:) -%>
+
 <%# we deliver our simple javascript as inline script to make deployment more
   reliable without having to deal with different asset pipelines, and it's really a fine choice anyway  %>
-
 <script type="text/javascript">
   async function turnstileCallback(token) {
     try {

--- a/app/views/bot_challenge_page/_turnstile_widget_placeholder.html.erb
+++ b/app/views/bot_challenge_page/_turnstile_widget_placeholder.html.erb
@@ -1,5 +1,6 @@
+<%# locals: (bot_challenge_config:) -%>
 <div
   class="cf-turnstile"
-  data-sitekey="<%= cf_turnstile_sitekey %>"
+  data-sitekey="<%= bot_challenge_config.cf_turnstile_sitekey %>"
   data-callback="turnstileCallback"
 ></div>

--- a/app/views/bot_challenge_page/bot_challenge_page/challenge.html.erb
+++ b/app/views/bot_challenge_page/bot_challenge_page/challenge.html.erb
@@ -1,7 +1,7 @@
 <div class="bot_challenge_page">
   <h1 class="mb-4"><%= t('bot_challenge_page.title') %></h1>
 
-  <%= render "bot_challenge_page/turnstile_widget_placeholder", bot_challenge_config: bot_challenge_config %>
+  <%= render "bot_challenge_page/turnstile_widget_placeholder", bot_challenge_config: @bot_challenge_config %>
 
   <noscript>
     <div class="alert alert-danger"><%= t('bot_challenge_page.noscript') %></div>
@@ -16,14 +16,14 @@
     </div>
   </template>
 
-  <template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= bot_challenge_config.still_around_delay_ms %>">
+  <template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= @bot_challenge_config.still_around_delay_ms %>">
     <div class="alert alert-info" role="alert">
       <i class="fa fa-info-circle" aria-hidden="true"></i>
       <%= t('bot_challenge_page.still_around') %>
     </div>
   </template>
 
-  <script src="<%= bot_challenge_config.cf_turnstile_js_url %>" async defer></script>
+  <script src="<%= @bot_challenge_config.cf_turnstile_js_url %>" async defer></script>
 
-  <%= render "bot_challenge_page/local_turnstile_script_tag", bot_challenge_config: bot_challenge_config %>
+  <%= render "bot_challenge_page/local_turnstile_script_tag", bot_challenge_config: @bot_challenge_config %>
 </div>

--- a/app/views/bot_challenge_page/bot_challenge_page/challenge.html.erb
+++ b/app/views/bot_challenge_page/bot_challenge_page/challenge.html.erb
@@ -1,7 +1,7 @@
 <div class="bot_challenge_page">
   <h1 class="mb-4"><%= t('bot_challenge_page.title') %></h1>
 
-  <%= render "bot_challenge_page/turnstile_widget_placeholder" %>
+  <%= render "bot_challenge_page/turnstile_widget_placeholder", bot_challenge_config: bot_challenge_config %>
 
   <noscript>
     <div class="alert alert-danger"><%= t('bot_challenge_page.noscript') %></div>
@@ -16,14 +16,14 @@
     </div>
   </template>
 
-  <template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= still_around_delay_ms %>">
+  <template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= bot_challenge_config.still_around_delay_ms %>">
     <div class="alert alert-info" role="alert">
       <i class="fa fa-info-circle" aria-hidden="true"></i>
       <%= t('bot_challenge_page.still_around') %>
     </div>
   </template>
 
-  <script src="<%= cf_turnstile_js_url %>" async defer></script>
+  <script src="<%= bot_challenge_config.cf_turnstile_js_url %>" async defer></script>
 
-  <%= render "bot_challenge_page/local_turnstile_script_tag" %>
+  <%= render "bot_challenge_page/local_turnstile_script_tag", bot_challenge_config: bot_challenge_config %>
 </div>

--- a/lib/generators/bot_challenge_page/install_generator.rb
+++ b/lib/generators/bot_challenge_page/install_generator.rb
@@ -3,10 +3,14 @@ module BotChallengePage
     source_root File.expand_path("templates", __dir__)
 
     class_option :'rack_attack', type: :boolean, default: true, desc: "Support rate-limit allowance configuration"
+    class_option :redirect_for_challenge, type: :boolean, default: false, desc: "Redirect to separate challenge page instead of inline challenge"
 
     def generate_routes
-      route 'get "/challenge", to: "bot_challenge_page/bot_challenge_page#challenge", as: :bot_detect_challenge'
-      route 'post "/challenge", to: "bot_challenge_page/bot_challenge_page#verify_challenge"'
+      route 'post "/challenge", to: "bot_challenge_page/bot_challenge_page#verify_challenge", as: :bot_detect_challenge'
+
+      if options[:redirect_for_challenge]
+        route 'get "/challenge", to: "bot_challenge_page/bot_challenge_page#challenge"'
+      end
     end
 
     def add_before_filter_enforcement

--- a/lib/generators/bot_challenge_page/templates/initializer.rb.erb
+++ b/lib/generators/bot_challenge_page/templates/initializer.rb.erb
@@ -4,8 +4,13 @@ Rails.application.config.to_prepare do
 
   # Get from CloudFlare Turnstile: https://www.cloudflare.com/application-services/products/turnstile/
   # Some testing keys are also available: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+  #
+  # Always pass testing sitekey: "1x00000000000000000000AA"
   BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_sitekey = "MUST GET"
+  # Always pass testing secret_key: "1x0000000000000000000000000000000AA"
   BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_secret_key = "MUST GET"
+
+  BotChallengePage::BotChallengePageController.bot_challenge_config.redirect_for_challenge = <%= options[:redirect_for_challenge] %>
 
   <%- if options[:rack_attack] %>
   # What paths do you want to protect?

--- a/spec/controllers/bot_challenge_page_controller_spec.rb
+++ b/spec/controllers/bot_challenge_page_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BotChallengePage::BotChallengePageController, type: :controller d
     it "renders and includes expected values" do
       get :challenge
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(403)
       expect(response.body).to include I18n.t("bot_challenge_page.title")
       expect(response.body).to include I18n.t("bot_challenge_page.blurb_html")
 
@@ -48,7 +48,7 @@ RSpec.describe BotChallengePage::BotChallengePageController, type: :controller d
 
       post :verify_challenge, params: { cf_turnstile_response: "XXXX.DUMMY.TOKEN.XXXX" }
       expect(response.status).to be 200
-      expect(response.body).to eq turnstile_response.to_json
+      expect(response.body).to eq turnstile_response.merge({"redirect_for_challenge" => controller.bot_challenge_config.redirect_for_challenge}).to_json
 
       expect(session[described_class.bot_challenge_config.session_passed_key]).to be_present
       expect(Time.iso8601(session[described_class.bot_challenge_config.session_passed_key][described_class::SESSION_DATETIME_KEY])).to be_within(60).of(Time.now.utc)
@@ -61,7 +61,7 @@ RSpec.describe BotChallengePage::BotChallengePageController, type: :controller d
 
       post :verify_challenge, params: { cf_turnstile_response: "XXXX.DUMMY.TOKEN.XXXX" }
       expect(response.status).to be 200
-      expect(response.body).to eq turnstile_response.to_json
+      expect(response.body).to eq turnstile_response.merge({"redirect_for_challenge" => controller.bot_challenge_config.redirect_for_challenge}).to_json
 
       expect(session[described_class.bot_challenge_config.session_passed_key]).not_to be_present
     end

--- a/spec/controllers/enforce_filter_spec.rb
+++ b/spec/controllers/enforce_filter_spec.rb
@@ -34,6 +34,7 @@ describe DummyController, type: :controller do
       get :index
 
       expect(response).to have_http_status(403)
+      expect(response.headers["Cache-Control"]).to eq "no-store"
       expect(response.body).to include I18n.t("bot_challenge_page.title")
       expect(response.body).to include I18n.t("bot_challenge_page.blurb_html")
     end

--- a/spec/controllers/enforce_immediate_filter_spec.rb
+++ b/spec/controllers/enforce_immediate_filter_spec.rb
@@ -28,6 +28,7 @@ describe DummyImmediateController, type: :controller do
       get :index
 
       expect(response).to have_http_status(403)
+      expect(response.headers["Cache-Control"]).to eq "no-store"
       expect(response.body).to include I18n.t("bot_challenge_page.title")
     end
 

--- a/spec/controllers/enforce_immediate_filter_spec.rb
+++ b/spec/controllers/enforce_immediate_filter_spec.rb
@@ -22,15 +22,16 @@ describe DummyImmediateController, type: :controller do
   end
 
   describe "when rack key requests bot challenge on protected controller" do
-    it "redirects even with no ENV request" do
+    render_views
+
+    it "displays challenge even with no ENV request" do
       get :index
 
-      expect(response).to have_http_status(307)
-      expect(response).to redirect_to(bot_detect_challenge_path(dest: dummy_immediate_path))
+      expect(response).to have_http_status(403)
+      expect(response.body).to include I18n.t("bot_challenge_page.title")
     end
 
-    # we configured this to try to exempt fetch/ajax to #facet
-    it "does not redirect if we have stored a pass in session" do
+    it "displays actual page if we have stored a pass in session" do
       request.session[BotChallengePage::BotChallengePageController.bot_challenge_config.session_passed_key] = {
           BotChallengePage::BotChallengePageController::SESSION_DATETIME_KEY => Time.now.utc.iso8601,
           BotChallengePage::BotChallengePageController::SESSION_IP_KEY   => request.remote_ip

--- a/spec/dummy/app/controllers/dummy_controller.rb
+++ b/spec/dummy/app/controllers/dummy_controller.rb
@@ -1,8 +1,12 @@
 class DummyController < ApplicationController
-  before_action { |controller| BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller) }
+  # normal one for index
+  before_action(only: :index) { |controller| BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller) }
+
+  # immediate one for download please
+  before_action(only: :download) { |controller| BotChallengePage::BotChallengePageController.bot_challenge_enforce_filter(controller, immediate: true) }
 
   def index
-    render plain: "rendered action dummy"
+    render plain: "rendered action dummy#index"
   end
 
   # just give us download content-disposition headers to test that

--- a/spec/dummy/app/views/optional/some_template.html.erb
+++ b/spec/dummy/app/views/optional/some_template.html.erb
@@ -1,6 +1,6 @@
 <h1>Some Template Rendered</h1>
 
-<%= render "bot_challenge_page/turnstile_widget_placeholder", bot_challenge_config: bot_challenge_config %>
+<%= render "bot_challenge_page/turnstile_widget_placeholder", bot_challenge_config: @bot_challenge_config %>
 
 <template id="botChallengePageErrorTemplate">
   <div class="alert alert-danger" role="alert">
@@ -9,13 +9,13 @@
   </div>
 </template>
 
-<template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= bot_challenge_config.still_around_delay_ms %>">
+<template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= @bot_challenge_config.still_around_delay_ms %>">
   <div class="alert alert-info" role="alert">
     <i class="fa fa-info-circle" aria-hidden="true"></i>
     <%= t('bot_challenge_page.still_around') %>
   </div>
 </template>
 
-<script src="<%= bot_challenge_config.cf_turnstile_js_url %>" async defer></script>
+<script src="<%= @bot_challenge_config.cf_turnstile_js_url %>" async defer></script>
 
-<%= render "bot_challenge_page/local_turnstile_script_tag", bot_challenge_config: bot_challenge_config %>
+<%= render "bot_challenge_page/local_turnstile_script_tag", bot_challenge_config: @bot_challenge_config %>

--- a/spec/dummy/app/views/optional/some_template.html.erb
+++ b/spec/dummy/app/views/optional/some_template.html.erb
@@ -1,6 +1,6 @@
 <h1>Some Template Rendered</h1>
 
-<%= render "bot_challenge_page/turnstile_widget_placeholder" %>
+<%= render "bot_challenge_page/turnstile_widget_placeholder", bot_challenge_config: bot_challenge_config %>
 
 <template id="botChallengePageErrorTemplate">
   <div class="alert alert-danger" role="alert">
@@ -9,13 +9,13 @@
   </div>
 </template>
 
-<template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= still_around_delay_ms %>">
+<template id="botChallengePageStillAroundTemplate" data-still_around_delay_ms="<%= bot_challenge_config.still_around_delay_ms %>">
   <div class="alert alert-info" role="alert">
     <i class="fa fa-info-circle" aria-hidden="true"></i>
     <%= t('bot_challenge_page.still_around') %>
   </div>
 </template>
 
-<script src="<%= cf_turnstile_js_url %>" async defer></script>
+<script src="<%= bot_challenge_config.cf_turnstile_js_url %>" async defer></script>
 
-<%= render "bot_challenge_page/local_turnstile_script_tag" %>
+<%= render "bot_challenge_page/local_turnstile_script_tag", bot_challenge_config: bot_challenge_config %>

--- a/spec/dummy/config/initializers/bot_challenge_page.rb
+++ b/spec/dummy/config/initializers/bot_challenge_page.rb
@@ -6,8 +6,8 @@ Rails.application.config.to_prepare do
   BotChallengePage::BotChallengePageController.bot_challenge_config.enabled = true
 
   # Get from CloudFlare Turnstile: https://www.cloudflare.com/application-services/products/turnstile/
-  BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_sitekey = "MUST GET"
-  BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_secret_key = "MUST GET"
+  BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_sitekey = "1x00000000000000000000AA"
+  BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_secret_key = "1x0000000000000000000000000000000AA"
 
   # What paths do you want to protect?
   #

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   # Capyabara.javascript_driver setting directly applies to 'feature' spec
   Capybara.default_driver = :rack_test # Faster but doesn't do Javascript
   Capybara.javascript_driver = ENV['SHOW_BROWSER'] ? :selenium_chrome : :selenium_chrome_headless
-
+  Capybara.javascript_driver = :selenium_chrome
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/system/long_page_system_spec.rb
+++ b/spec/system/long_page_system_spec.rb
@@ -7,17 +7,17 @@ describe "Challenge page stays around persistently", type: :system do
     # shorten up the delay to make the test faster
     orig = BotChallengePage::BotChallengePageController.bot_challenge_config.dup
     BotChallengePage::BotChallengePageController.bot_challenge_config.still_around_delay_ms = 1
+
     # auto-pass-key
     BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_sitekey = "1x00000000000000000000AA"
     BotChallengePage::BotChallengePageController.bot_challenge_config.cf_turnstile_secret_key = "1x0000000000000000000000000000000AA"
 
+    BotChallengePage::BotChallengePageController.rack_attack_init
 
     example.run
 
     BotChallengePage::BotChallengePageController.bot_challenge_config = orig
   end
-
-
 
   before do
     stub_turnstile_success(request_body: {
@@ -27,10 +27,41 @@ describe "Challenge page stays around persistently", type: :system do
   end
 
   it "shows appropriate message" do
-    # our destination is a forced download, so they never naviagate anywhere else
-    visit "/challenge?dest=#{dummy_download_path}"
+    visit dummy_download_path
 
-    # show it eventually should show them the message we show in that case
-    expect(page).to have_text(I18n.t('bot_challenge_page.still_around'), wait: 7) # it takes a while sorry not sure why
+    # this is protected with immediate challenge, inline, so first they should see the challenge page
+    expect(page).to have_content(I18n.t("bot_challenge_page.title"))
+
+    # and eventually theys hould see the still-around message we show when there
+    # was no nav after challenge success
+    expect(page).to have_text(I18n.t('bot_challenge_page.still_around'), wait: 7) # not sure why we need to wait so long to see it
+  end
+
+  describe "with redirect" do
+    around do |example|
+      orig = BotChallengePage::BotChallengePageController.bot_challenge_config.dup
+      BotChallengePage::BotChallengePageController.bot_challenge_config.redirect_for_challenge = true
+
+      example.run
+
+      BotChallengePage::BotChallengePageController.bot_challenge_config = orig
+    end
+
+    it "shows appropriate message" do
+      # our destination is a forced download, so they never naviagate anywhere else
+      visit "/challenge?dest=#{dummy_download_path}"
+
+      expect(page).to have_content(I18n.t("bot_challenge_page.title"))
+
+      # show it eventually should show them the message we show in that case
+      expect(page).to have_text(I18n.t('bot_challenge_page.still_around'), wait: 7) # it takes a while sorry not sure why
+    end
+  end
+
+  describe "without redirect" do
+    around do |example|
+      orig = BotChallengePage::BotChallengePageController.bot_challenge_config.dup
+
+    end
   end
 end

--- a/spec/system/long_page_system_spec.rb
+++ b/spec/system/long_page_system_spec.rb
@@ -57,11 +57,4 @@ describe "Challenge page stays around persistently", type: :system do
       expect(page).to have_text(I18n.t('bot_challenge_page.still_around'), wait: 7) # it takes a while sorry not sure why
     end
   end
-
-  describe "without redirect" do
-    around do |example|
-      orig = BotChallengePage::BotChallengePageController.bot_challenge_config.dup
-
-    end
-  end
 end


### PR DESCRIPTION
The "api" to templates is now a bit hackier, necessarily using a controller iVar. 

Which also means backwards incompat changes to anyone who tried to customize templates. Sorry, we're pre-1.0. 

- default challenge render spells out template, to prepare for inline challenge
- templates have clear passed in local single config, to prepare for inline rendering in other controllers
- add new default inline rendering of challenge
- installer handles redirect_for_challenge or not
