### PR TITLE
add after_session_passed hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ##
 
+## 1.1.0
+
+* after_session_passed config: We sometimes want to log or otherwise note when a request is let in because it has a session cookie pass. https://github.com/samvera-labs/bot_challenge_page/pull/20
+
 ## 1.0.0
 
 * No logic change from 0.11.0, decided to call it a 1.0 release.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ config.after_blocked = (_bot_challenge_class)->  {
 }
 ```
 
+If you'd like to log every time a request is let through because it has a verified session pass,
+which could be a lot of data, use `after_session_pass`.
+
+```ruby
+config.after_session_pass = (_bot_challenge_class)->  {
+  logger.info("page allowed through by session pass: #{request.uri}")
+}
+```
+
+
 Or, here's how I managed to get it in [lograge](https://github.com/roidrage/lograge), so a page blocked results in a `bot_chlng=true` param in a lograge line.
 
 ```ruby

--- a/app/controllers/concerns/bot_challenge_page/guard_action.rb
+++ b/app/controllers/concerns/bot_challenge_page/guard_action.rb
@@ -13,7 +13,7 @@ module BotChallengePage
       # Render challenge page when necessary, otherwise do nothing allowing ordinary rails render.
       def bot_challenge_guard_action(controller)
         if self.bot_challenge_config.enabled &&
-            ! self._bot_detect_passed_good?(controller.request) &&
+            ! self._bot_detect_passed_good?(controller) &&
             ! controller.kind_of?(self) # don't ever guard ourself, that'd be a mess!
 
           # we can only do GET requests right now
@@ -51,7 +51,9 @@ module BotChallengePage
 
       # Does the session already contain a bot detect pass that is good for this request
       # Tie to IP address to prevent session replay shared among IPs
-      def _bot_detect_passed_good?(request)
+      def _bot_detect_passed_good?(controller)
+        request = controller.request
+
         session_data = request.session[self.bot_challenge_config.session_passed_key]
 
         return false unless session_data && session_data.kind_of?(Hash)
@@ -61,7 +63,9 @@ module BotChallengePage
         fingerprint   = session_data[self::SESSION_FINGERPRINT_KEY]
 
         (Time.now - Time.iso8601(datetime) < self.bot_challenge_config.session_passed_good_for ) &&
-        fingerprint == self.bot_challenge_config.session_valid_fingerprint.call(request)
+        (fingerprint == self.bot_challenge_config.session_valid_fingerprint.call(request)) &&
+        # not a real condition, just to call our hook on passed
+        (controller.instance_exec(self, &self.bot_challenge_config.after_session_passed) || true)
       end
     end
   end

--- a/lib/bot_challenge_page/config.rb
+++ b/lib/bot_challenge_page/config.rb
@@ -45,6 +45,8 @@ module BotChallengePage
 
     attribute :after_blocked, default: ->(bot_detect_class) {}
 
+    attribute :after_session_passed, default: ->(bot_detect_class) {}
+
 
     # rate limit per subnet, follow lehigh's lead with
     # subnet: /16 for IPv4 (x.y.*.*), and /64 for IPv6 (about the same size subnet for better or worse)

--- a/spec/controllers/bot_challenge_page_controller_spec.rb
+++ b/spec/controllers/bot_challenge_page_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe BotChallengePage::BotChallengePageController, type: :controller d
       expect(session[described_class.bot_challenge_config.session_passed_key]).to be_present
       expect(Time.iso8601(session[described_class.bot_challenge_config.session_passed_key][described_class::SESSION_DATETIME_KEY])).to be_within(60).of(Time.now.utc)
 
-      expect(described_class._bot_detect_passed_good?(request)).to be true
+      expect(described_class._bot_detect_passed_good?(controller)).to be true
     end
 
     it "handles turnstile failure" do

--- a/spec/controllers/enforce_filter_spec.rb
+++ b/spec/controllers/enforce_filter_spec.rb
@@ -110,6 +110,42 @@ describe DummyRateLimitController, type: :controller do
         expect($arg).to be BotChallengePage::BotChallengePageController
       end
     end
+
+
+    describe "custom pass logging via after_session_passed" do
+      around do |example|
+        $triggered = false
+        $self = nil
+        $arg = nil
+        with_bot_challenge_config(BotChallengePage::BotChallengePageController,
+          after_session_passed: ->(bot_detect_class) {
+            $triggered = true;
+            $self = self;
+            $arg = bot_detect_class
+          }
+        ) { example.run }
+      end
+
+      it "does not call if not passed" do
+        get :immediate
+        expect($triggered).to be false
+      end
+
+      it "does call if passed" do
+        # store valid pass in session
+        request.session[BotChallengePage::BotChallengePageController.bot_challenge_config.session_passed_key] = {
+            BotChallengePage::BotChallengePageController::SESSION_DATETIME_KEY => Time.now.utc.iso8601,
+            BotChallengePage::BotChallengePageController::SESSION_FINGERPRINT_KEY   =>
+              BotChallengePage::BotChallengePageController.bot_challenge_config.session_valid_fingerprint.call(request)
+        }
+
+        get :immediate
+
+        expect($triggered).to be true
+        expect($self).to be_an_instance_of(described_class)
+        expect($arg).to be BotChallengePage::BotChallengePageController
+      end
+    end
   end
 
   describe "rate limited filter" do


### PR DESCRIPTION
We sometimes want to log or otherwise note when a request is let in because it has a session cookie pass. Add config to make that possible. 

See https://github.com/sciencehistory/scihist_digicoll/pull/3316